### PR TITLE
feat(app): Gerenciamento de profissionais e refatora o controller de User na API

### DIFF
--- a/BackEnd/src/main/java/br/com/projeto2/aajjl/controller/UserController.java
+++ b/BackEnd/src/main/java/br/com/projeto2/aajjl/controller/UserController.java
@@ -1,16 +1,17 @@
 package br.com.projeto2.aajjl.controller;
 
-import br.com.projeto2.aajjl.dto.responses.ResponseDTO;
+import br.com.projeto2.aajjl.dto.requests.UserUpdateDTO;
+import br.com.projeto2.aajjl.dto.responses.UserResponseDTO;
 import br.com.projeto2.aajjl.model.Profession;
 import br.com.projeto2.aajjl.model.User;
 import br.com.projeto2.aajjl.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-
 import java.util.List;
-import java.util.Optional;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/usuarios")
@@ -19,62 +20,75 @@ public class UserController {
     @Autowired
     private UserService userService;
 
-    //CReate
     @PostMapping
-    public ResponseEntity<ResponseDTO> createUser(@RequestBody User newUser) {
-        ResponseDTO response = userService.create(newUser);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<UserResponseDTO> createUser(@RequestBody User newUser) {
+        User savedUser = userService.createAndSave(newUser);
+        return ResponseEntity.status(HttpStatus.CREATED).body(UserResponseDTO.fromEntity(savedUser));
     }
 
-    //ListAll - GetAll
+    // ListAll - GetAll (Já estava correto)
     @GetMapping
-    public ResponseEntity<List<User>> getAllUsers() {
-        return ResponseEntity.ok(userService.getAll());
+    public ResponseEntity<List<UserResponseDTO>> getAllUsers() {
+        List<User> users = userService.getAll();
+        List<UserResponseDTO> responseDTOs = users.stream()
+                .map(UserResponseDTO::fromEntity)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responseDTOs);
     }
 
-    //Get by ID
     @GetMapping("/{id}")
-    public ResponseEntity<User> getUserById(@PathVariable Long id) {
-        Optional<User> foundUser = userService.getById(id);
-        return foundUser.map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+    public ResponseEntity<UserResponseDTO> getUserById(@PathVariable Long id) {
+        return userService.getById(id)
+                .map(user -> ResponseEntity.ok(UserResponseDTO.fromEntity(user)))
+                .orElse(ResponseEntity.notFound().build());
     }
 
-    //Put
     @PutMapping("/{id}")
-    public ResponseEntity<User> updateUser(@PathVariable Long id, @RequestBody User oldUser) {
-        Optional<User> updated = userService.update(id, oldUser);
-        return updated.map(ResponseEntity::ok).orElse(ResponseEntity.notFound().build());
+    public ResponseEntity<UserResponseDTO> updateUser(@PathVariable Long id, @RequestBody UserUpdateDTO updateUserDTO) {
+        return userService.update(id, updateUserDTO)
+                .map(user -> ResponseEntity.ok(UserResponseDTO.fromEntity(user)))
+                .orElse(ResponseEntity.notFound().build());
     }
 
-    //Soft Delete
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
         boolean deleted = userService.delete(id);
         return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
     }
 
-    //Find by nome
     @GetMapping("/search/nome")
-    public ResponseEntity<List<User>> findByNome(@RequestParam String name) {
-        return ResponseEntity.ok(userService.findByNome(name));
+    public ResponseEntity<List<UserResponseDTO>> findByNome(@RequestParam String name) {
+        List<User> users = userService.findByNome(name);
+        List<UserResponseDTO> responseDTOs = users.stream()
+                .map(UserResponseDTO::fromEntity)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responseDTOs);
     }
 
-    //Find by Profissao
     @GetMapping("/search/profissao")
-    public ResponseEntity<List<User>> findByProfissao(@RequestParam Profession profession) {
-        return ResponseEntity.ok(userService.findByProfissao(profession));
+    public ResponseEntity<List<UserResponseDTO>> findByProfissao(@RequestParam Profession profession) {
+        List<User> users = userService.findByProfissao(profession);
+        List<UserResponseDTO> responseDTOs = users.stream()
+                .map(UserResponseDTO::fromEntity)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responseDTOs);
     }
 
-    //Find by Ativo(True)
     @GetMapping("/ativos")
-    public ResponseEntity<List<User>> getAllAtivos() {
-        return ResponseEntity.ok(userService.getAllAtivos());
+    public ResponseEntity<List<UserResponseDTO>> getAllAtivos() {
+        List<User> users = userService.getAllAtivos();
+        List<UserResponseDTO> responseDTOs = users.stream()
+                .map(UserResponseDTO::fromEntity)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responseDTOs);
     }
 
-    //Find by Ativo(False)
     @GetMapping("/inativos")
-    public ResponseEntity<List<User>> getAllInativos() {
-        return ResponseEntity.ok(userService.getAllInativos());
+    public ResponseEntity<List<UserResponseDTO>> getAllInativos() {
+        List<User> users = userService.getAllInativos();
+        List<UserResponseDTO> responseDTOs = users.stream()
+                .map(UserResponseDTO::fromEntity)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(responseDTOs);
     }
 }
-

--- a/BackEnd/src/main/java/br/com/projeto2/aajjl/dto/requests/UserUpdateDTO.java
+++ b/BackEnd/src/main/java/br/com/projeto2/aajjl/dto/requests/UserUpdateDTO.java
@@ -1,0 +1,12 @@
+package br.com.projeto2.aajjl.dto.requests;
+
+import br.com.projeto2.aajjl.model.Profession;
+
+public record UserUpdateDTO(
+        String nome,
+        String email,
+        String consenhoRegional,
+        Profession profissao,
+        Boolean ativo
+) {
+}

--- a/BackEnd/src/main/java/br/com/projeto2/aajjl/dto/responses/UserResponseDTO.java
+++ b/BackEnd/src/main/java/br/com/projeto2/aajjl/dto/responses/UserResponseDTO.java
@@ -1,0 +1,26 @@
+package br.com.projeto2.aajjl.dto.responses;
+
+import br.com.projeto2.aajjl.model.Profession;
+import br.com.projeto2.aajjl.model.User;
+
+public record UserResponseDTO(
+        Long id,
+        String nome,
+        String email,
+        String cpf,
+        Profession profissao,
+        String consenhoRegional,
+        Boolean ativo
+) {
+    public static UserResponseDTO fromEntity(User user) {
+        return new UserResponseDTO(
+                user.getId(),
+                user.getNome(),
+                user.getEmail(),
+                user.getCpf(),
+                user.getProfissao(),
+                user.getConsenhoRegional(),
+                user.getAtivo()
+        );
+    }
+}

--- a/BackEnd/src/main/java/br/com/projeto2/aajjl/service/UserService.java
+++ b/BackEnd/src/main/java/br/com/projeto2/aajjl/service/UserService.java
@@ -1,21 +1,15 @@
 package br.com.projeto2.aajjl.service;
 
-
-import br.com.projeto2.aajjl.dto.responses.ResponseDTO;
-
+import br.com.projeto2.aajjl.dto.requests.UserUpdateDTO;
 import br.com.projeto2.aajjl.model.Profession;
 import br.com.projeto2.aajjl.model.User;
-
 import br.com.projeto2.aajjl.repository.UserRepository;
-import br.com.projeto2.aajjl.security.TokenService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
-
 
 @Service
 public class UserService {
@@ -29,92 +23,51 @@ public class UserService {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    @Autowired
-    private TokenService tokenService;
-
-    public ResponseDTO create(User newUser) {
+    public User createAndSave(User newUser) {
 
         if (userRepository.findByEmail(newUser.getEmail()).isPresent()) {
             throw new RuntimeException("E-mail já cadastrado");
         }
 
         newUser.setSenha(passwordEncoder.encode(newUser.getSenha()));
-
         newUser.setAtivo(true);
 
         User savedUser = userRepository.save(newUser);
 
-//        emailService.enviarEmailSimples(
-//                savedUser.getEmail(),
-//                "Bem-vindo ao Sistema de assistencia para visitas domiciliares",
-//                "Olá " + savedUser.getNome() + ", seu cadastro foi realizado com sucesso!"
-//        );
+        // emailService.enviarEmailSimples(
+        //         savedUser.getEmail(),
+        //         "Bem-vindo ao Sistema de assistencia para visitas domiciliares",
+        //         "Olá " + savedUser.getNome() + ", seu cadastro foi realizado com sucesso!"
+        // );
 
-        String token = this.tokenService.generateToken(savedUser);
-        return new ResponseDTO(
-                savedUser.getNome(),
-                savedUser.getCpf(),
-                savedUser.getConsenhoRegional(),
-                savedUser.getEmail(),
-                savedUser.getProfissao(),
-                savedUser.getAtivo(),
-                token
-        );
-
+        return savedUser;
     }
 
+    public Optional<User> update(Long id, UserUpdateDTO updateDTO) {
+        return userRepository.findById(id)
+                .map(existingUser -> {
+                    if (updateDTO.nome() != null) existingUser.setNome(updateDTO.nome());
+                    if (updateDTO.email() != null) existingUser.setEmail(updateDTO.email());
+                    if (updateDTO.consenhoRegional() != null) existingUser.setConsenhoRegional(updateDTO.consenhoRegional());
+                    if (updateDTO.profissao() != null) existingUser.setProfissao(updateDTO.profissao());
+                    if (updateDTO.ativo() != null) existingUser.setAtivo(updateDTO.ativo());
+
+                    return userRepository.save(existingUser);
+                });
+    }
+
+
     public List<User> getAll() {
-        return userRepository.findAll()
-                .stream()
-                .filter(User::getAtivo)
-                .toList();
+        return userRepository.findAll();
     }
 
     public Optional<User> getById(Long id) {
-        return userRepository.findById(id).filter(User::getAtivo);
-    }
-
-    public Optional<User> update(Long id, User novo) {
-
-        User atual = userRepository.findById(id)
-                .orElseThrow(() ->
-                        new RuntimeException("Não foi possível atualizar: usuário " + id + " não encontrado."));
-
-        for (Field field : User.class.getDeclaredFields()) {
-            field.setAccessible(true);
-
-            if ("id".equals(field.getName())) {
-                continue;
-            }
-
-            try {
-                Object novoValor = field.get(novo);
-
-                if (novoValor == null) {
-                    continue;
-                }
-                if (novoValor instanceof String str && str.trim().isEmpty()) {
-                    continue;
-                }
-
-                if (novoValor instanceof String str) {
-                    novoValor = str.trim();
-                }
-
-                field.set(atual, novoValor);
-
-            } catch (IllegalAccessException e) {
-                throw new RuntimeException(
-                        "Erro ao atualizar o campo " + field.getName(), e);
-            }
-        }
-
-        return Optional.of(userRepository.save(atual));
+        return userRepository.findById(id);
     }
 
     public boolean delete(Long id) {
         return userRepository.findById(id).map(user -> {
-            user.setAtivo(false); //Aqui eu nao deleto do BD, eu atualizo o atributo para false
+            user.setAtivo(false);
             userRepository.save(user);
             return true;
         }).orElse(false);
@@ -141,5 +94,4 @@ public class UserService {
     public List<User> getAllInativos() {
         return userRepository.findByAtivoFalse();
     }
-
 }

--- a/sistemaFront/src/components/Header/index.tsx
+++ b/sistemaFront/src/components/Header/index.tsx
@@ -70,6 +70,26 @@ const Header = () => {
             Listar
             <br /> Pacientes
           </p>
+                    <p
+            style={{
+              cursor: "pointer",
+              transition: "background 0.2s, color 0.2s",
+              borderRadius: "6px",
+              padding: "4px 8px",
+            }}
+            onMouseOver={(e) => {
+              (e.currentTarget as HTMLElement).style.background = "#f0f0f0";
+              (e.currentTarget as HTMLElement).style.color = "#061a2e";
+            }}
+            onMouseOut={(e) => {
+              (e.currentTarget as HTMLElement).style.background = "transparent";
+              (e.currentTarget as HTMLElement).style.color = "inherit";
+            }}
+            onClick={() => navigate("/listagemProfissionais")}
+          >
+            Listar
+            <br /> Profissionais
+          </p>
           <p
             style={{
               cursor: "pointer",

--- a/sistemaFront/src/models/User.ts
+++ b/sistemaFront/src/models/User.ts
@@ -1,4 +1,17 @@
-export type Profession = "MEDICO" | "ENFERMEIRO" | "ASSISTENTE_SOCIAL" | "PSICOLOGO";
+export type Profession =
+  | "MEDICO"
+  | "ENFERMEIRO"
+  | "ENFERMEIRO_CHEFE"
+  | "ASSISTENTE_SOCIAL"
+  | "PACIENTE"
+  | "AGENTE_DE_SAÚDE_ACS"
+  | "CLINICO_GERAL"
+  | "NUTRICIONISTA"
+  | "FISIOTERAPEUTA"
+  | "DENTISTA"
+  | "PSICOLOGO"
+  | "PSIQUIATRA"
+  | "PEDIATRA";
 
 
 export type User = {

--- a/sistemaFront/src/pages/ListagemProffissionais/index.tsx
+++ b/sistemaFront/src/pages/ListagemProffissionais/index.tsx
@@ -1,0 +1,102 @@
+import * as S from "./style";
+import * as React from "react";
+import Header from "../../components/Header";
+import { getAllUsersAPI } from "../../services/AuthService"; 
+import type { User } from "../../models/User";
+import {
+  Button,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Paper,
+} from "@mui/material";
+import EditIcon from "@mui/icons-material/Edit";
+import ControlPointTwoToneIcon from "@mui/icons-material/ControlPointTwoTone";
+import { useNavigate } from "react-router-dom";
+
+const Row = ({ user }: { user: User }) => {
+  const navigate = useNavigate();
+
+  return (
+    <TableRow sx={{ "& > *": { borderBottom: "unset" } }}>
+      <TableCell>{user.nome}</TableCell>
+      <TableCell>{user.email}</TableCell>
+      <TableCell>{user.cpf}</TableCell>
+      <TableCell>{user.profissao}</TableCell>
+      <TableCell>{user.consenhoRegional}</TableCell>
+      <TableCell>
+        <span
+          style={{ color: user.ativo ? "green" : "red", fontWeight: "bold" }}
+        >
+          {user.ativo ? "Sim" : "Não"}
+        </span>
+      </TableCell>
+      <TableCell>
+        <Button
+          onClick={() =>
+            navigate("/editar-profissional", { state: { id: user.id } })
+          }
+        >
+          <EditIcon />
+        </Button>
+      </TableCell>
+    </TableRow>
+  );
+};
+
+const ListagemProfissionais = () => {
+  const [users, setUsers] = React.useState<User[]>([]);
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    const fetchUsers = async () => {
+      const data = await getAllUsersAPI();
+      if (data) {
+        setUsers(data);
+        console.log("Profissionais carregados:", data);
+      }
+    };
+
+    fetchUsers();
+  }, []);
+
+  return (
+    <S.Container>
+      <Header />
+      <S.ContainerTable>
+        <Button
+          className="button"
+          onClick={() => navigate("/cadastro-de-profissional")}
+        >
+          <p className="text">Novo Profissional</p>
+          <ControlPointTwoToneIcon />
+        </Button>
+        <TableContainer component={Paper} className="table">
+          <Table aria-label="collapsible table">
+            <TableHead>
+              <TableRow>
+                <TableCell>Nome</TableCell>
+                <TableCell>Email</TableCell>
+                <TableCell>CPF</TableCell>
+                <TableCell>Profissão</TableCell>
+                <TableCell>Conselho Regional</TableCell>
+                <TableCell>Ativo</TableCell>
+                <TableCell>Editar</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {users.map((user) => (
+                <Row key={user.id} user={user} />
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      </S.ContainerTable>
+    </S.Container>
+  );
+};
+
+export default ListagemProfissionais;

--- a/sistemaFront/src/pages/ListagemProffissionais/style.ts
+++ b/sistemaFront/src/pages/ListagemProffissionais/style.ts
@@ -1,0 +1,69 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const LogoGroup = styled.div`
+  display: flex;
+  gap: 2rem;
+  margin-bottom: 1rem;
+`;
+
+export const Logo = styled.img`
+  height: 6rem;
+  will-change: filter;
+  transition: filter 300ms;
+  &:hover {
+    filter: drop-shadow(0 0 2em #646cffaa);
+  }
+
+  &.react:hover {
+    filter: drop-shadow(0 0 2em #61dafbaa);
+  }
+`;
+
+export const Title = styled.h1`
+  font-size: 3rem;
+  margin-bottom: 1rem;
+`;
+
+export const Card = styled.div`
+  padding: 2em;
+  background-color: #f4f4f5;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+  box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.1);
+`;
+
+export const Paragraph = styled.p`
+  font-size: 0.875rem;
+  color: #888;
+`;
+export const ContainerTable = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: 5rem;
+  width: 70%;
+
+  .table {
+    background-color: #d9d9d9;
+    margintop: 3;
+  }
+  .button {
+    margin-bottom: 1rem;
+    margin-left: auto;
+    background-color: #b9d3ee;
+    border-radius: 20px;
+    box-shadow: 0px 9px 12px 0px rgba(127, 127, 127, 0.75);
+    -webkit-box-shadow: 0px 9px 12px 0px rgba(127, 127, 127, 0.75);
+    -moz-box-shadow: 0px 9px 12px 0px rgba(127, 127, 127, 0.75);
+  }
+  .text {
+    color: #fff;
+    margin-right: 0.3rem;
+  }
+`;

--- a/sistemaFront/src/pages/editarProfissional/index.tsx
+++ b/sistemaFront/src/pages/editarProfissional/index.tsx
@@ -1,0 +1,181 @@
+import * as S from "./style";
+import TextField from "@mui/material/TextField";
+import {
+  Button,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+} from "@mui/material";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import Header from "../../components/Header";
+import { toast } from "react-toastify";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useEffect } from "react";
+import { getUserByIdAPI, updateUserAPI } from "../../services/AuthService";
+import type { Profession, User } from "../../models/User";
+
+const schema = yup.object({
+  nome: yup.string().required("Nome é obrigatório"),
+  cpf: yup
+    .string()
+    .matches(/^\d{11}$/, "CPF deve conter 11 dígitos numéricos")
+    .required("CPF é obrigatório"),
+  consenhoRegional: yup.string().required("Conselho Regional é obrigatório"),
+  email: yup.string().email("Email inválido").required("Email é obrigatório"),
+  profissao: yup.string().required("Profissão é obrigatória"),
+});
+
+type FormData = yup.InferType<typeof schema>;
+
+const EditarProfissional = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { id } = location.state || {};
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+    reset,
+  } = useForm<FormData>({
+    resolver: yupResolver(schema),
+    mode: "onChange",
+  });
+
+  useEffect(() => {
+    if (!id) {
+      toast.error("ID do profissional não fornecido.");
+      navigate("/listagem-profissionais");
+      return;
+    }
+
+    const fetchProfissional = async () => {
+      try {
+        const user = await getUserByIdAPI(Number(id));
+        if (user) {
+          reset({
+            nome: user.nome,
+            cpf: user.cpf,
+            email: user.email,
+            consenhoRegional: user.consenhoRegional,
+            profissao: user.profissao,
+          });
+          console.log("Dados do profissional", user);
+        } else {
+          toast.error("Profissional não encontrado");
+        }
+      } catch (error) {
+        console.error("Erro ao buscar dados do profissional:", error);
+        toast.error("Erro ao buscar dados do profissional.");
+      }
+    };
+
+    fetchProfissional();
+  }, [id, reset, navigate]);
+
+  const onSubmit = async (data: FormData) => {
+    try {
+      const updateData: Partial<User> = {
+        ...data,
+        profissao: data.profissao as Profession,
+      };
+
+      await updateUserAPI(Number(id), updateData);
+      toast.success("Profissional atualizado com sucesso!");
+      navigate("/listagemProfissionais");
+    } catch (error) {
+      console.error("Erro ao atualizar profissional:", error);
+      toast.error("Erro ao atualizar profissional");
+    }
+  };
+
+  return (
+    <S.Container>
+      <Header />
+      <S.Title>Editar Dados do Profissional</S.Title>
+      <S.Card style={{ padding: "20px" }}>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <TextField
+            fullWidth
+            label="Nome"
+            variant="filled"
+            {...register("nome")}
+            error={!!errors.nome}
+            helperText={errors.nome?.message}
+            InputLabelProps={{ shrink: true }}
+            margin="normal"
+          />
+          <TextField
+            fullWidth
+            label="CPF"
+            variant="filled"
+            {...register("cpf")}
+            error={!!errors.cpf}
+            helperText={errors.cpf?.message}
+            InputLabelProps={{ shrink: true }}
+            margin="normal"
+          />
+          <TextField
+            fullWidth
+            label="Email"
+            variant="filled"
+            {...register("email")}
+            error={!!errors.email}
+            helperText={errors.email?.message}
+            InputLabelProps={{ shrink: true }}
+            margin="normal"
+          />
+          <TextField
+            fullWidth
+            label="Conselho Regional"
+            variant="filled"
+            {...register("consenhoRegional")}
+            error={!!errors.consenhoRegional}
+            helperText={errors.consenhoRegional?.message}
+            InputLabelProps={{ shrink: true }}
+            margin="normal"
+          />
+          <FormControl fullWidth variant="filled" margin="normal">
+            <InputLabel id="profissao-label">Profissão</InputLabel>
+            <Select
+              labelId="profissao-label"
+              defaultValue=""
+              {...register("profissao")}
+              error={!!errors.profissao}
+            >
+              <MenuItem value="MEDICO">Médico</MenuItem>
+              <MenuItem value="ENFERMEIRO">Enfermeiro</MenuItem>
+              <MenuItem value="ENFERMEIRO_CHEFE">Enfermeiro Chefe</MenuItem>
+              <MenuItem value="ASSISTENTE_SOCIAL">Assistente Social</MenuItem>
+              <MenuItem value="AGENTE_DE_SAÚDE_ACS">
+                Agente de Saúde (ACS)
+              </MenuItem>
+              <MenuItem value="CLINICO_GERAL">Clínico Geral</MenuItem>
+              <MenuItem value="NUTRICIONISTA">Nutricionista</MenuItem>
+              <MenuItem value="FISIOTERAPEUTA">Fisioterapeuta</MenuItem>
+              <MenuItem value="DENTISTA">Dentista</MenuItem>
+              <MenuItem value="PSICOLOGO">Psicólogo</MenuItem>
+              <MenuItem value="PSIQUIATRA">Psiquiatra</MenuItem>
+              <MenuItem value="PEDIATRA">Pediatra</MenuItem>
+            </Select>
+          </FormControl>
+
+          <Button
+            type="submit"
+            variant="contained"
+            fullWidth
+            disabled={!isValid}
+            sx={{ mt: 2 }}
+          >
+            Atualizar Profissional
+          </Button>
+        </form>
+      </S.Card>
+    </S.Container>
+  );
+};
+
+export default EditarProfissional;

--- a/sistemaFront/src/pages/editarProfissional/style.ts
+++ b/sistemaFront/src/pages/editarProfissional/style.ts
@@ -1,0 +1,78 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const Title = styled.h1`
+  font-size: 2rem;
+  margin-bottom: 1rem;
+`;
+
+export const Entrada = styled.div`
+  margin-bottom: 5%;
+  margin-top: 5%;
+  .prioridade {
+    width: 200%;
+  }
+`;
+
+export const ContainerInputs = styled.div`
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  gap: 1rem;
+  align-items: center;
+`;
+
+export const Card = styled.div`
+  width: 100%;
+  max-width: 900px;
+  padding: 2em;
+  background-color: #ffffff;
+  border-radius: 30px;
+  margin-bottom: 1rem;
+  box-shadow: 2px 4px 12px rgba(0, 0, 0, 0.1);
+  gap: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+
+  .input {
+    width: 100%;
+    flex: 1;
+    justify-content: flex-start;
+  }
+
+  .button {
+    background-color: #98b8f3;
+  }
+
+  .padd {
+    margin-bottom: 5%;
+    margin-top: 5%;
+  }
+
+  .txt {
+    mmargin-top: 5%;
+    text-align: center;
+    font-size: 0.8rem;
+  }
+
+  .txt2 {
+    color: #1976d2;
+    text-decoration: none;
+    font-weight: 500;
+  }
+`;
+
+export const Background = styled.div`
+  background-color: #d2d2d2;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;

--- a/sistemaFront/src/routes/index.tsx
+++ b/sistemaFront/src/routes/index.tsx
@@ -9,8 +9,10 @@ import CadastroProfissional from "../pages/cadastroProfissional";
 import CadastroPaciente from "../pages/cadastroPaciente";
 import Agendamento from "../pages/agendamento";
 import EditarPaciente from "../pages/editarPaciente";
-import ForgotPassword from '../pages/ForgotPassword';
-import ResetPassword from '../pages/ResetPassword';
+import ForgotPassword from "../pages/ForgotPassword";
+import ResetPassword from "../pages/ResetPassword";
+import ListagemProffissionais from "../pages/ListagemProffissionais";
+import EditarProfissional from "../pages/editarProfissional";
 
 export const AppRoutes = () => {
   const { isLoggedIn, isReady } = useAuth();
@@ -21,7 +23,7 @@ export const AppRoutes = () => {
       <Route
         path="/"
         element={
-          isLoggedIn() ? <Navigate to="/principal" replace /> : <Login   />
+          isLoggedIn() ? <Navigate to="/principal" replace /> : <Login />
         }
       />
       <Route path="/cadastro" element={<Cadastro />} />
@@ -34,6 +36,7 @@ export const AppRoutes = () => {
           </ProtectedRoute>
         }
       />
+
       <Route
         path="/listagem"
         element={
@@ -43,7 +46,15 @@ export const AppRoutes = () => {
         }
       />
 
-        
+      <Route
+        path="/listagemProfissionais"
+        element={
+          <ProtectedRoute>
+            <ListagemProffissionais />
+          </ProtectedRoute>
+        }
+      />
+
       <Route path="/reset-password" element={<ResetPassword />} />
       <Route path="/forgot-password" element={<ForgotPassword />} />
 
@@ -76,6 +87,14 @@ export const AppRoutes = () => {
         element={
           <ProtectedRoute>
             <EditarPaciente />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/editar-profissional"
+        element={
+          <ProtectedRoute>
+            <EditarProfissional />
           </ProtectedRoute>
         }
       />

--- a/sistemaFront/src/services/AuthService.tsx
+++ b/sistemaFront/src/services/AuthService.tsx
@@ -55,7 +55,7 @@ export const getAllUsersAPI = async () => {
 
 export const getUserByIdAPI = async (id: number) => {
   try {
-    const response = await axios.get<User>(`${api}/${id}`);
+    const response = await axios.get<User>(`${api}/api/usuarios/${id}`);
     return response.data;
   } catch (error) {
     handleError(error);
@@ -65,7 +65,7 @@ export const getUserByIdAPI = async (id: number) => {
 
 export const updateUserAPI = async (id: number, user: Partial<User>) => {
   try {
-    const response = await axios.put<User>(`${api}/${id}`, user);
+    const response = await axios.put<User>(`${api}/api/usuarios/${id}`, user);
     return response.data;
   } catch (error) {
     handleError(error);
@@ -75,7 +75,7 @@ export const updateUserAPI = async (id: number, user: Partial<User>) => {
 
 export const deleteUserAPI = async (id: number) => {
   try {
-    await axios.delete(`${api}/${id}`);
+    await axios.delete(`${api}/api/usuarios/${id}`);
   } catch (error) {
     handleError(error);
   }


### PR DESCRIPTION
## Backend:
 - Correções de Segurança: A API retornava as entidades JPA diretamente, o que causava dois problemas graves:
   - Exposição de Dados Sensíveis e Loops Infinitos de Serialização: Relacionamentos bidirecionais (ex: User <-> Patient) causavam um loop ao converter os objetos para JSON, quebrando a resposta da API.
 - Foram criados DTOs específicos para as respostas
 - Todos os endpoints nos Controllers de User и Patient foram refatorados para receber e retornar DTOs, nunca mais expondo a entidade diretamente.
 - A camada de Service agora contém a lógica de negócio para converter DTOs em entidades antes de salvar no banco de dados.
---
## Frontend:
- Novas Funcionalidades e Rotas:
 - Página de Listagem de Profissionais
 - Página de Edição de Profissional
 - Os componentes foram ajustados para consumir os UserResponseDTO em vez das entidades completas, alinhando-se com a nova arquitetura do backend.